### PR TITLE
Let "rightMenu" switch correctly when slideOutThenIn = YES.

### DIFF
--- a/SASlideMenu/ExampleDynamicMenuViewController.m
+++ b/SASlideMenu/ExampleDynamicMenuViewController.m
@@ -99,10 +99,11 @@
 }
 //Disable caching for the controller at the first row of each section
 -(Boolean) disableContentViewControllerCachingForIndexPath:(NSIndexPath *)indexPath{
-    if (indexPath.row ==0) {
-        return YES;
-    }
-    return NO;
+//    if (indexPath.row ==0) {
+//        return YES;
+//    }
+//    return NO;
+    return YES;
 }
 
 //Enable the right menu for the the view controller in the first section

--- a/SASlideMenu/SASlideMenu/SASlideMenuContentSegue.m
+++ b/SASlideMenu/SASlideMenu/SASlideMenuContentSegue.m
@@ -58,7 +58,7 @@
         layer.shadowPath =[UIBezierPath bezierPathWithRect:layer.bounds].CGPath;
     }
     
-    [rootController switchToContentViewController:destination];
+    [rootController switchToContentViewController:destination completion:nil];
 
     if ([rootController.leftMenu.slideMenuDataSource respondsToSelector:@selector(segueIdForIndexPath:)]) {
         [rootController addContentViewController:destination withIndexPath:selectedIndexPath];        

--- a/SASlideMenu/SASlideMenu/SASlideMenuRootViewController.h
+++ b/SASlideMenu/SASlideMenu/SASlideMenuRootViewController.h
@@ -19,7 +19,7 @@
 @property (nonatomic,assign) Boolean isRightMenuEnabled;
 @property (nonatomic,strong) SASlideMenuNavigationController* navigationController;
 
--(void) switchToContentViewController:(UINavigationController*) content;
+-(void) switchToContentViewController:(UINavigationController*) content completion:(void (^)(void))completion;
 -(void) addContentViewController:(UIViewController*) content withIndexPath:(NSIndexPath*)indexPath;
 
 -(void) popRightNavigationController;

--- a/SASlideMenu/SASlideMenu/SASlideMenuViewController.m
+++ b/SASlideMenu/SASlideMenu/SASlideMenuViewController.m
@@ -43,7 +43,7 @@
     if ([self.slideMenuDataSource respondsToSelector:@selector(segueIdForIndexPath:)]) {
         UINavigationController* controller = [self.rootController controllerForIndexPath:indexPath];
         if (controller) {
-            [self.rootController switchToContentViewController:controller];
+            [self.rootController switchToContentViewController:controller completion:nil];
             return;
         }
         NSString* segueId = [self.slideMenuDataSource segueIdForIndexPath:indexPath];


### PR DESCRIPTION
issue:  slideOutThenIn = YES, "rightMenu" switch wrong.

In SASlideMenuContentSegue,

run       [destination performSegueWithIdentifier:@"rightMenu" sender:rootController];
before  switchToContentViewController animate slideOut , completed.
cause  SASlideMenuRightMenuSegue.perform [source.parentViewController == nil]

workaroud:
run    [destination performSegueWithIdentifier:@"rightMenu" sender:rootController];
after  (void) switchToContentViewController:(UINavigationController*) content completion:(void (^)(void))completion;

MARK:  My first github pull request.....
