### PR TITLE
Update SASlideMenuRootViewController.m - resize menuView

### DIFF
--- a/SASlideMenu/SASlideMenu/SASlideMenuRootViewController.m
+++ b/SASlideMenu/SASlideMenu/SASlideMenuRootViewController.m
@@ -580,6 +580,16 @@ typedef enum {
     [self performSegueWithIdentifier:@"leftMenu" sender:self];
 }
 
+- (void)viewDidLayoutSubviews {
+  
+  [super viewDidLayoutSubviews];
+  
+  CGRect frame = [self.view bounds];
+  frame.size.width = [self leftMenuSize];
+  self.menuView.frame = frame;
+}
+
+
 -(void) didReceiveMemoryWarning{
     [super didReceiveMemoryWarning];
     [controllers removeAllObjects];


### PR DESCRIPTION
When using the same SASlideMenu in iPhone and iPad, I've found that the leftMenu does not expand to the height of the display automatically.   This patch appears to address the problems I was seeing.

Code will adjust the frame of the menuView when the MenuRoot is adjusted, I suspect there may be a similar issue for the right menu, but haven't tested yet
